### PR TITLE
Chore/prevent console log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 0.0.3 (2021-11-08)
+
+
+### Features
+
+* Add new methods of cache-busting and add read-me ([27d28ab](https://github.com/alexnewmannn/cache-bust/commit/27d28ab49c5f0563daf164572dec38b0fad1db23))
+
+
+### Bug Fixes
+
+* add copyFile function ([17b15f6](https://github.com/alexnewmannn/cache-bust/commit/17b15f6598c20200769fa48938bbdd54c4859e0e))

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const crypto = require('crypto');
 const fs = require('fs');
-const process = require('process');
+const cbDebug = require('debug')('cache-bust:debug');
 
 const generateHash = (dir, sourceFile) => {
   const file = fs.readFileSync((`${dir}${sourceFile}`), 'utf8');
@@ -13,7 +13,7 @@ const generateHash = (dir, sourceFile) => {
   const splitFile = removeExtension[0].split('/');
   const fileName = splitFile.pop();
   const destination = sourceFile.replace(fileName, `${fileName}-${hash}`);
-  console.log(`${dir}${sourceFile}`, `${dir}${destination}`);
+  cbDebug(`${dir}${sourceFile}`, `${dir}${destination}`);
   fs.copyFile(`${dir}${sourceFile}`, `${dir}${destination}`, (copyErr) => {
     if (copyErr) {
       throw copyErr;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "cache-busting-assets",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-busting-assets",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
the component has a console.log in which can cause issues when reading anything from stdout.  I've swapped it out for npm debug so it can be turned on and off as required. 